### PR TITLE
add focal to ubuntu suits

### DIFF
--- a/debian_conf/pbuilderrc
+++ b/debian_conf/pbuilderrc
@@ -18,7 +18,7 @@ DEBIAN_SUITES=($UNSTABLE_CODENAME $TESTING_CODENAME $STABLE_CODENAME $STABLE_BAC
     "experimental" "unstable" "testing" "stable")
 
 # List of Ubuntu suites. Update these when needed.
-UBUNTU_SUITES=("disco" "bionic" "xenial")
+UBUNTU_SUITES=("focal" "disco" "bionic" "xenial")
 
 # Mirrors to use. Update these to your preferred mirror.
 DEBIAN_MIRROR="http://mirror.aarnet.edu.au/pub/debian/"


### PR DESCRIPTION
I ran into a problem attempting to add the mercury-lang repository in Ubuntu focal.

I did not actually run/build anything but a quick search of the source led me to this place where "focal" appears to be missing.


What I tried:

broken mercury.list:

```
deb http://dl.mercurylang.org/deb/ focal main
deb-src http://dl.mercurylang.org/deb/ focal main
```

Resulting Error:

`The repository 'http://dl.mercurylang.org/deb focal Release' does not have a Release file`



But this works:

```
deb http://dl.mercurylang.org/deb/ stretch main
deb-src http://dl.mercurylang.org/deb/ stretch main
```